### PR TITLE
patch: externalize ws lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waforix/mocha",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "bun run --watch src/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target node",
+    "build": "bun build src/index.ts --outdir dist --target node --external ws",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",


### PR DESCRIPTION
Externalize the websocket library, because, for some reason god only knows, its creating a bug specifically in the built version of mocha that causes everything to just blow up.