### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -1,4 +1,6 @@
 name: TypeScript Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/waforix/mocha/security/code-scanning/5](https://github.com/waforix/mocha/security/code-scanning/5)

To fix this issue, add a `permissions` block to the workflow YAML to explicitly restrict the permissions granted to the `GITHUB_TOKEN`. The best way is to set the minimal permissions required, which for this workflow is almost certainly just `contents: read`. This can be added at the top-level (workflow-wide—applies to all jobs unless a job overrides it), or to the specific `typescript-check` job if for some reason only that job requires restriction. Here, adding at the workflow (top) level is clearest and consistent with best practices. Place the following after the workflow `name` line and before `on:` (e.g., after line 1):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed because this is YAML configuration for GitHub Actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
