### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Format Check


### PR DESCRIPTION
Potential fix for [https://github.com/waforix/mocha/security/code-scanning/4](https://github.com/waforix/mocha/security/code-scanning/4)

The workflow should explicitly set the least privilege permissions for the job or the workflow. Since all steps are local (`checkout`, setup bun, install dependencies, check formatting) and do not push or modify the repository, the job only needs read access to repository contents. Add a `permissions:` block with `contents: read` either at the root (to apply to all jobs) or at the job level (applies to this job only). The best approach is to add this just above the `jobs:` section (after the workflow name and triggers) so all jobs in this workflow inherit least-privilege settings by default. No additional imports, code, or steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
