### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,4 +1,6 @@
 name: Lint Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/waforix/mocha/security/code-scanning/3](https://github.com/waforix/mocha/security/code-scanning/3)

The best way to remediate this issue is to add a `permissions:` block to the workflow, granting the minimum required privileges. Since the jobs in this workflow only need to check out and read code, the minimal permissions required are `contents: read`. This block can be added at the workflow root (after the `name:` field), ensuring that all jobs in the workflow inherit these settings.

- Add the following lines directly after the `name: ...` statement at the top of `.github/workflows/lint-check.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- This change does not alter workflow functionality but improves security by enforcing the least privilege principle.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
