### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/biome-check.yml
+++ b/.github/workflows/biome-check.yml
@@ -1,4 +1,6 @@
 name: Biome Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/waforix/mocha/security/code-scanning/2](https://github.com/waforix/mocha/security/code-scanning/2)

To fix this problem, we must restrict the permissions used by the workflow. The minimal and safest approach is to explicitly specify a `permissions` section with only the least-privilege required. Since the steps in this workflow simply check out the code and run local commands, the workflow only needs `contents: read` permissions. This should be declared at either the workflow root (for all jobs) or at the job level. The best option is to add it at the root level, so it applies universally and will be inherited by all jobs unless specifically overridden.

Add the following section after `name:` and before `on:` in `.github/workflows/biome-check.yml`:
```yaml
permissions:
  contents: read
```

No imports, method definitions, or other special constructs are needed—just the correct YAML syntax and placement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
