### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish to NPM
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/waforix/mocha/security/code-scanning/1](https://github.com/waforix/mocha/security/code-scanning/1)

To fix this problem, we need to add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum necessary. Since this workflow only checks out code and publishes to NPM (using an external token), most likely it only needs `contents: read`. This can be added either at the root of the workflow (applies to all jobs), or specifically within the `publish` job. The recommended way (and as per CodeQL suggestion) is to add the block at the root, just after the `name` line and before the `on` trigger definition. No new imports or dependencies are needed; just an edit to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
