### PR TITLE
fix(db): return Date for PostgreSQL timestamps instead of number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waforix/mocha",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -2,7 +2,6 @@ export function toTimestamp(date: Date): Date {
   return date;
 }
 
-
 export function fromTimestamp(timestamp: number): Date {
   return new Date(timestamp * 1000);
 }

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,7 +1,7 @@
 export function toTimestamp(date: Date): Date {
   return date;
 }
-}
+
 
 export function fromTimestamp(timestamp: number): Date {
   return new Date(timestamp * 1000);

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,5 +1,5 @@
-export function toTimestamp(date: Date): number {
-  return Math.floor(date.getTime() / 1000);
+export function toTimestamp(date: Date): Date | number {
+  return date;
 }
 
 export function fromTimestamp(timestamp: number): Date {

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,5 +1,6 @@
-export function toTimestamp(date: Date): Date | number {
+export function toTimestamp(date: Date): Date {
   return date;
+}
 }
 
 export function fromTimestamp(timestamp: number): Date {


### PR DESCRIPTION
fix(db): return Date objects for PostgreSQL timestamp queries

The toTimestamp() function was converting Date objects to Unix timestamps
(numbers), which caused drizzle-orm to fail when building PostgreSQL queries
with timestamp parameters. PostgreSQL timestamp columns expect Date objects,
not numbers.

Changed toTimestamp() to return the Date object directly instead of converting
it to a number. This fixes the "value.toISOString is not a function" error
when querying stats with date filters.

Fixes compatibility with drizzle-orm PostgreSQL timestamp handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Internal timestamp/date handling now consistently uses Date objects, simplifying date processing and reducing unnecessary numeric conversions.

- **Chores**
  - Package version bumped to 2.2.1 and related type declarations aligned with the new date approach.

- **User Impact**
  - No visible UI or behavior changes; purely internal consistency and maintainability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->